### PR TITLE
feat: support `attributes` parameter

### DIFF
--- a/src/Navigation.php
+++ b/src/Navigation.php
@@ -23,6 +23,11 @@ class Navigation implements Node
         $this->children = [];
     }
 
+    public static function make(): static
+    {
+        return app(static::class);
+    }
+
     public function add(string $title = '', string $url = '', ?callable $configure = null): self
     {
         $section = new Section($this, $title, $url);

--- a/src/Section.php
+++ b/src/Section.php
@@ -35,7 +35,7 @@ class Section implements Node
         $this->children = [];
     }
 
-    public function add(string $title = '', string $url = '', ?callable $configure = null): self
+    public function add(string $title = '', string $url = '', ?callable $configure = null, ?array $attributes = null): self
     {
         $section = new Section($this, $title, $url);
 
@@ -43,15 +43,19 @@ class Section implements Node
             $configure($section);
         }
 
+        if ($attributes) {
+            $section->attributes($attributes);
+        }
+
         $this->children[] = $section;
 
         return $this;
     }
 
-    public function addIf($condition, string $title = '', string $url = '', ?callable $configure = null): self
+    public function addIf($condition, string $title = '', string $url = '', ?callable $configure = null, ?array $attributes = null): self
     {
         if ($this->resolveCondition($condition)) {
-            $this->add($title, $url, $configure);
+            $this->add($title, $url, $configure, $attributes);
         }
 
         return $this;

--- a/tests/SectionTest.php
+++ b/tests/SectionTest.php
@@ -58,6 +58,15 @@ class SectionTest extends TestCase
         $this->assertEquals('qux', $section->children[0]->attributes['baz']);
     }
 
+    public function test_attributes_can_be_configured_inline()
+    {
+        $section = (new Section($this->navigation, 'Top level', '/'))
+            ->add('First link', '/link', attributes: ['icon' => 'mdi:link']);
+
+        $this->assertCount(1, $section->children);
+        $this->assertArrayHasKey('icon', $section->children[0]->attributes);
+    }
+
     public function test_it_has_depth()
     {
         $section = (new Section($this->navigation, 'Hello, world!', '/'))->add('Blog', '/posts');


### PR DESCRIPTION
This PR adds an `attributes` parameter to `Section@add` and `Section@addIf`, as a convenience.

The use case is to commonly have attributes (in my case icons or "external" booleans, for an Inertia front-end), and using the `$configure` callback is a lot of boilerplate and highly inconvenient for this purpose.

Additionally, as a QoL, I added a static `make` method to `Navigation` to avoid doing `app(Navigation::class)` manually.

**Before**

```php
app(Navigation::class)
    ->add('Home', route('home'), fn (Section $section) => $section->attributes(['icon' => 'mdi:home']))
    ->add('Blog', route('blog.index'), function (Section $section) {
        $section
            ->add('All posts', route('blog.index'), fn (Section $section) => $section->attributes(['icon' => 'mdi:document']))
            ->add('Topics', route('blog.topics.index'), fn (Section $section) => $section->attributes(['icon' => 'mdi:label']));
    })
    ->addIf(Auth::user()->isAdmin(), function (Navigation $navigation) {
        $navigation->add('Admin', route('admin.index'), fn (Section $section) => $section->attributes(['icon' => 'mdi:lock']));
    });
```

**After**

```php
Navigation::make()
    ->add('Home', route('home'), attributes: ['icon' => 'mdi:home'])
    ->add('Blog', route('blog.index'), function (Section $section) {
        $section
            ->add('All posts', route('blog.index'), attributes: ['icon' => 'mdi:document'])
            ->add('Topics', route('blog.topics.index'), attributes: ['icon' => 'mdi:label']);
    })
    ->addIf(Auth::user()->isAdmin(), function (Navigation $navigation) {
        $navigation->add('Admin', route('admin.index'), attributes: ['icon' => 'mdi:lock']);
    });
```

Unfortunately I add to keep `$configure` the third parameter to preserve backwards compatibility, but named attributes mitigate the inconvenience and it's good enough for me.