### PR TITLE
feat: support rendering the current section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The main goal of Laravel Menu is to build HTML menus from PHP. Laravel Navigatio
 ```php
 // typically, in a service provider
 
-app(Navigation::class)
+Navigation::make()
     ->add('Home', route('home'))
     ->add('Blog', route('blog.index'), function (Section $section) {
         $section
@@ -32,7 +32,7 @@ Some examples when visiting `/blog/topics/laravel`:
 
 ```php
 // Render to tree
-app(Navigation::class)->tree();
+Navigation::make()->tree();
 ```
 
 ```json
@@ -53,10 +53,10 @@ app(Navigation::class)->tree();
 
 ```php
 // Append additional pages in your controller
-app(Navigation::class)->activeSection()->add($topic->name, route('blog.topics.show', $topic));
+Navigation::make()->activeSection()->add($topic->name, route('blog.topics.show', $topic));
 
 // Render to breadcrumbs
-app(Navigation::class)->breadcrumbs();
+Navigation::make()->breadcrumbs();
 ```
 
 ```json
@@ -65,6 +65,15 @@ app(Navigation::class)->breadcrumbs();
     { "title": "Topics", "url": "/blog/topics" },
     { "title": "Laravel", "url": "/blog/topics/laravel" }
 ]
+```
+
+```php
+// Render the current section
+Navigation::make()->current();
+```
+
+```json
+{ "title": "Home", "url": "/", "attributes": [] }
 ```
 
 ## Support us

--- a/src/Navigation.php
+++ b/src/Navigation.php
@@ -4,6 +4,7 @@ namespace Spatie\Navigation;
 
 use Spatie\Navigation\Helpers\ActiveUrlChecker;
 use Spatie\Navigation\Renderers\BreadcrumbsRenderer;
+use Spatie\Navigation\Renderers\SectionRenderer;
 use Spatie\Navigation\Renderers\TreeRenderer;
 use Spatie\Navigation\Traits\Conditions as ConditionsTrait;
 
@@ -104,6 +105,11 @@ class Navigation implements Node
     public function breadcrumbs(): array
     {
         return (new BreadcrumbsRenderer($this))->render();
+    }
+
+    public function current(): ?array
+    {
+        return (new SectionRenderer($this->activeSection()))->render();
     }
 
     public function getParent(): ?Node

--- a/src/Renderers/SectionRenderer.php
+++ b/src/Renderers/SectionRenderer.php
@@ -7,7 +7,7 @@ use Spatie\Navigation\Section;
 class SectionRenderer
 {
     public function __construct(
-        private ?Section $section
+        protected ?Section $section
     ) {
     }
 

--- a/src/Renderers/SectionRenderer.php
+++ b/src/Renderers/SectionRenderer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\Navigation\Renderers;
+
+use Spatie\Navigation\Section;
+
+class SectionRenderer
+{
+    public function __construct(
+        private ?Section $section
+    ) {
+    }
+
+    public function render(): ?array
+    {
+        if (!$this->section) {
+            return null;
+        }
+        
+        return [
+            'url' => $this->section->url,
+            'title' => $this->section->title,
+            'attributes' => $this->section->attributes,
+        ];
+    }
+}

--- a/tests/NavigationTest.php
+++ b/tests/NavigationTest.php
@@ -37,6 +37,11 @@ class NavigationTest extends TestCase
         $this->assertEquals('Topics', $activeSection->title);
     }
 
+    public function test_it_can_render_the_active_section()
+    {
+        $this->assertMatchesSnapshot($this->navigation->current());
+    }
+
     public function test_it_returns_null_when_there_is_no_active_section()
     {
         $activeSection = (new Navigation($this->activeUrlChecker))->add('Home', '/')->activeSection();

--- a/tests/NavigationTest.php
+++ b/tests/NavigationTest.php
@@ -42,6 +42,14 @@ class NavigationTest extends TestCase
         $this->assertMatchesSnapshot($this->navigation->current());
     }
 
+    public function test_it_returns_null_when_rendering_an_empty_section()
+    {
+        $navigation =  (new Navigation($this->activeUrlChecker))->add('Home', '/');
+
+        $this->assertNull($navigation->activeSection());
+        $this->assertNull($navigation->current());
+    }
+
     public function test_it_returns_null_when_there_is_no_active_section()
     {
         $activeSection = (new Navigation($this->activeUrlChecker))->add('Home', '/')->activeSection();

--- a/tests/__snapshots__/NavigationTest__test_it_can_render_the_active_section__1.yml
+++ b/tests/__snapshots__/NavigationTest__test_it_can_render_the_active_section__1.yml
@@ -1,0 +1,3 @@
+url: /topics
+title: Topics
+attributes: {  }


### PR DESCRIPTION
When using this package with Inertia, I often need the current section to display data related to the current page. Unfortunately, this is quite hard to achieve - I need to create a custom renderer in my application code. 

This PR solves that problem by adding a new `SectionRenderer` and a `current` method on `Navigation`, in order to render the section that is currently active.

Additionally, I updated the docs to add an example of this feature, and updated the previous examples to use `Navigation::make()` instead of `app(Navigation::class)`.