### PR TITLE
in_array strict mode

### DIFF
--- a/src/Navigation.php
+++ b/src/Navigation.php
@@ -58,7 +58,7 @@ class Navigation implements Node
             return false;
         }
 
-        return in_array($section, array_merge([$activeSection], $activeSection->getParents()));
+        return in_array($section, array_merge([$activeSection], $activeSection->getParents()), true);
     }
 
     public function activeSection(): ?Section


### PR DESCRIPTION
Hi guys,

while testing with PHPUnit in my project I got the following error 
`Fatal error: Nesting level too deep - recursive dependency? in vendor/spatie/laravel-navigation/src/Navigation.php on line 61`

As explained here: [Stackoverflow](https://stackoverflow.com/questions/8460011/in-array-on-objects-with-circular-references/8460312#8460312)

_It would appear that by default in_array does non-strict comparison (equivalent to an == operation) when testing the haystack for the needle. This means that it checks that all the properties are equal, which means it starts traversing the object graph, and that can get you into trouble if you have circular references in that graph._

### Solution

This PR activates the in_array strict mode in the file navigation.php on line 61 and with that the error does no longer pop-up.

### Environment where error appears
composer show spatie/laravel-navigation
versions : * 1.1.0

PHPUnit 9.5.25

Laravel Version ....................................................................................................... 9.32.0  
  PHP Version ........................................................................................................... 8.1.10  
  Composer Version ....................................................................................................... 2.4.2  
  Environment ............................................................................................................ local  
  Debug Mode ........................................................................................................... ENABLED 