### PR TITLE
refactor: move active url check logic to a method

### DIFF
--- a/src/Helpers/ActiveUrlChecker.php
+++ b/src/Helpers/ActiveUrlChecker.php
@@ -47,11 +47,12 @@ class ActiveUrlChecker
         $itemPath = Str::removeFromStart($rootPath, $itemPath);
         $matchPath = Str::removeFromStart($rootPath, $matchPath);
 
-        // If this url starts with the url we're matching with, it's active.
-        if ($matchPath === $itemPath || Str::startsWith($matchPath, $itemPath)) {
-            return true;
-        }
+        return $this->isActive($matchPath, $itemPath);
+    }
 
-        return false;
+    protected function isActive(string $matchPath, string $itemPath): bool
+    {
+        // If this url starts with the url we're matching with, it's active.
+        return $matchPath === $itemPath || Str::startsWith($matchPath, $itemPath);
     }
 }

--- a/tests/ActiveUrlCheckerTest.php
+++ b/tests/ActiveUrlCheckerTest.php
@@ -13,3 +13,18 @@ it('can check if an url is active', function (string $currentUrl, string $urlToC
     ['/bar', '/foo/bar', false],
     ['bar', 'bar', false], // Does not start with '/' which is the root path
 ]);
+
+it('can strictly check if an url is active', function (string $currentUrl, string $urlToCheck, bool $result) {
+    $checker = new class($urlToCheck, '/') extends ActiveUrlChecker
+    {
+        protected function isActive(string $matchPath, string $itemPath): bool
+        {
+            return $matchPath === $itemPath;
+        }
+    };
+
+    expect($checker->check($currentUrl))->toBe($result);
+})->with([
+    ['/', '/', true],
+    ['/foo', '/foo/bar', false],
+]);


### PR DESCRIPTION
Currently menu item marked as active even when it’s not equal, but has common prefix. Like `/about` and `/about/something`. But often it’s useful to strictly check for URL activity when both items are in the menu.

There is a discussion with solution for this case: https://github.com/spatie/laravel-navigation/discussions/20 but it requires copying of `ActiveUrlChecker` class.

This PR moves checking logic of the `ActiveUrlChecker` to a separate method for easier extending of this class. It’s a simple change that will not affect current work.